### PR TITLE
Functionality to associate user to an org on creation

### DIFF
--- a/lib/chef/knife/opc_org_create.rb
+++ b/lib/chef/knife/opc_org_create.rb
@@ -4,7 +4,7 @@
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
--# you may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Users wanted the ability to associate users to an existing organization upon creation with `knife opc create user`.
