### PR TITLE
Added command `knife opc user password`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Deletes the given OPC user.
 
 Will open $EDITOR. When finished, Knife will update the given OPC user.
 
+## knife opc user password USERNAME [PASSWORD | --enable_external_auth]
+
+Command for managing password and authentication for a user.
+
+The last argument should either be a string you want the password to or you can pass --enable_external_auth instead of a password to enable external authentication for this user.
+
 ## knife opc org list
 
   * `-w`, `--with-uri`:

--- a/lib/chef/knife/opc_user_password.rb
+++ b/lib/chef/knife/opc_user_password.rb
@@ -1,0 +1,73 @@
+#
+# Author:: Tyler Cloke (<tyler@getchef.com>)
+# Copyright:: Copyright 2014 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Opc
+  class OpcUserPassword < Chef::Knife
+    category "OPSCODE PRIVATE CHEF ORGANIZATION MANAGEMENT"
+    banner "knife opc user password USERNAME [PASSWORD | --enable_external_auth]"
+
+    option :enable_external_auth,
+    :long => "--enable-external-auth",
+    :short => "-e",
+    :description => "Enable external authentication for this user (such as LDAP)"
+
+    def run
+      # check that correct number of args was passed, should be either
+      # USERNAME PASSWORD or USERNAME --enable-external-auth
+      #
+      # note that you can't pass USERNAME PASSWORD --enable-external-auth
+      if !((@name_args.length == 2 && !config[:enable_external_auth]) || (@name_args.length == 1 && config[:enable_external_auth]))
+        show_usage
+        ui.fatal("You must pass two arguments")
+        ui.fatal("Note that --enable-external-auth cannot be passed with a password")
+        exit 1
+      end
+
+      user_name = @name_args[0]
+
+      # note that this will be nil if config[:enable_external_auth] is true
+      password = @name_args[1]
+
+      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
+
+      # since the API does not pass back whether recovery_authentication_enabled is
+      # true or false, there is no way of knowing if the user is using ldap or not,
+      # so we will update the user every time, instead of checking if we are actually
+      # changing anything before we PUT.
+      user =  @chef_rest.get_rest("users/#{user_name}")
+
+      user["password"] = password if not password.nil?
+
+      # if --enable-external-auth was passed, enable it, else disable it.
+      # there is never a situation where we would want to enable ldap
+      # AND change the password. changing the password means that the user
+      # wants to disable ldap and put user in recover (if they are using ldap).
+      user["recovery_authentication_enabled"] = !config[:enable_external_auth]
+
+      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
+      begin
+        result = @chef_rest.put_rest("users/#{user_name}", user)
+      rescue => e
+        raise e
+        exit 1
+      end
+      ui.msg user
+      ui.msg("Authentication info updated for #{user_name}.")
+    end
+  end
+end


### PR DESCRIPTION
Command either updates the password for a user or, if --enable_external_auth is passed instead of a password, it will enable ldap for that user.
