### PR TITLE
Show private key in response if user ask to regenerate it

### DIFF
--- a/lib/chef/knife/opc_user_edit.rb
+++ b/lib/chef/knife/opc_user_edit.rb
@@ -40,7 +40,6 @@ module Opc
       edited_user = edit_data(original_user)
       if original_user != edited_user
         @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
-        ui.msg edited_user
         result = @chef_rest.put_rest("users/#{user_name}", edited_user)
         ui.msg("Saved #{user_name}.")
         if ! result['private_key'].nil?


### PR DESCRIPTION
Hi folks,

Chef API description about how to update an user with the PUT method includes this comment:

`PUT accepts a boolean: { "private_key": "true" }. If this is specified, a new private key is generated.`

However, knife-opc is not showing the full server response and you can't see the new private key when is regenerated.

I don't know if my PR is acceptable but at least is a step in the right direction, IMO.

Thanks for open sourcing this, btw.

Miguel,
