### PR TITLE
Fix #17, ensure the keyfile is writable before creating a user

### DIFF
--- a/lib/chef/knife/opc_user_create.rb
+++ b/lib/chef/knife/opc_user_create.rb
@@ -54,6 +54,15 @@ module Opc
         :password =>     password
       }
 
+     # Check the file before creating the user so the api is more transactional.
+     if config[:filename]
+       file = config[:filename]
+       unless File.exists?(file) ? File.writable?(file) : File.writable?(File.dirname(file))
+         ui.fatal "File #{config[:filename]} is not writable.  Check permissions."
+         exit 1
+       end
+     end
+
       @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
       result = @chef_rest.post_rest("users/", user_hash)
       if config[:filename]


### PR DESCRIPTION
https://github.com/opscode/chef-server/issues/17 is the related issue.

This just ensures the file exists and is writable before creating the user.

Requires manual testing.
