### PR TITLE
Place add_user_to_org in explicitly required module

### DIFF
--- a/lib/chef/knife/opc_org_create.rb
+++ b/lib/chef/knife/opc_org_create.rb
@@ -35,6 +35,7 @@ module Opc
 
     deps do
       require 'chef/org'
+      require 'chef/org/group_operations'
     end
 
     def run

--- a/lib/chef/knife/opc_org_user_add.rb
+++ b/lib/chef/knife/opc_org_user_add.rb
@@ -29,6 +29,7 @@ module Opc
 
     deps do
       require 'chef/org'
+      require 'chef/org/group_operations'
     end
 
     def run

--- a/lib/chef/org.rb
+++ b/lib/chef/org.rb
@@ -1,11 +1,13 @@
 require 'chef/json_compat'
 require 'chef/mixin/params_validate'
 require 'chef/rest'
+require 'chef/org/group_operations'
 
 class Chef
   class Org
 
     include Chef::Mixin::ParamsValidate
+    include Chef::Org::GroupOperations
 
     def initialize(name='')
       @name = name
@@ -91,18 +93,6 @@ class Chef
 
     def dissociate_user(username)
       chef_rest.delete_rest "organizations/#{name}/users/#{username}"
-    end
-
-    def add_user_to_group(groupname, username)
-      group = chef_rest.get_rest "organizations/#{name}/groups/#{groupname}"
-      body_hash = {
-        :groupname => "#{groupname}",
-        :actors => {
-          "users" => group["actors"].concat([username]),
-          "groups" => group["groups"]
-        }
-      }
-      chef_rest.put_rest "organizations/#{name}/groups/#{groupname}", body_hash
     end
 
     # Class methods

--- a/lib/chef/org/group_operations.rb
+++ b/lib/chef/org/group_operations.rb
@@ -1,0 +1,20 @@
+require 'chef/org'
+
+class Chef
+  class Org
+    module GroupOperations
+      def add_user_to_group(groupname, username)
+        group = chef_rest.get_rest "organizations/#{name}/groups/#{groupname}"
+        body_hash = {
+          :groupname => "#{groupname}",
+          :actors => {
+            "users" => group["actors"].concat([username]),
+            "groups" => group["groups"]
+          }
+        }
+        chef_rest.put_rest "organizations/#{name}/groups/#{groupname}", body_hash
+      end
+    end
+    include Chef::Org::GroupOperations
+  end
+end


### PR DESCRIPTION
Chef 12.1+ contains a Chef::Org class that was derived from this class
but which is missing the add_user_to_org method. This is part of
ongoing work to move knife-opc into core chef.  However, this causes
undefined method errors since require 'chef/org' no longer loads our
version of this class.  Users of Chef 12.1 can now use:

   require 'chef/org/group_operations'

to add this method to the Chef::Org object.

Fixes #28