### PR TITLE
Explicitly use the v0 server API for all requests

### DIFF
--- a/lib/chef/knife/opc_org_delete.rb
+++ b/lib/chef/knife/opc_org_delete.rb
@@ -15,17 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'chef/mixin/root_rest'
 
 module Opc
   class OpcOrgDelete < Chef::Knife
     category "OPSCODE PRIVATE CHEF ORGANIZATION MANAGEMENT"
     banner "knife opc org delete ORG_NAME"
 
+    include Chef::Mixin::RootRestv0
+
     def run
       org_name = @name_args[0]
-      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
       ui.confirm "Do you want to delete the organization #{org_name}"
-      ui.output @chef_rest.delete_rest("organizations/#{org_name}")
+      ui.output root_rest.delete("organizations/#{org_name}")
     end
   end
 end

--- a/lib/chef/knife/opc_org_edit.rb
+++ b/lib/chef/knife/opc_org_edit.rb
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'chef/mixin/root_rest'
 
 module Opc
   class OpcOrgEdit < Chef::Knife
@@ -30,8 +31,9 @@ module Opc
         exit 1
       end
 
-      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
-      original_org =  @chef_rest.get_rest("organizations/#{org_name}")
+      include Chef::Mixin::RootRestv0
+
+      original_org =  root_rest.get("organizations/#{org_name}")
       edited_org = edit_data(original_org)
 
       if original_org == edited_org
@@ -39,9 +41,8 @@ module Opc
         exit
       end
 
-      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
       ui.msg edited_org
-      result = @chef_rest.put_rest("organizations/#{org_name}", edited_org)
+      root_rest.put("organizations/#{org_name}", edited_org)
       ui.msg("Saved #{org_name}.")
     end
   end

--- a/lib/chef/knife/opc_org_list.rb
+++ b/lib/chef/knife/opc_org_list.rb
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'chef/mixin/root_rest'
 
 module Opc
   class OpcOrgList < Chef::Knife
@@ -31,10 +32,11 @@ module Opc
     :short => "-a",
     :description => "Show auto-generated hidden orgs in output"
 
+    include Chef::Mixin::RootRestv0
+
     def run
-      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
-      results =  @chef_rest.get_rest("organizations")
-      unless config[:all_orgs] 
+      results =  root_rest.get("organizations")
+      unless config[:all_orgs]
         results = results.select { |k,v| !(k.length == 20 && k =~ /^[a-z]+$/) }
       end
       ui.output(ui.format_list_for_display(results))

--- a/lib/chef/knife/opc_org_show.rb
+++ b/lib/chef/knife/opc_org_show.rb
@@ -15,16 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'chef/mixin/root_rest'
 
 module Opc
   class OpcOrgShow < Chef::Knife
     category "OPSCODE PRIVATE CHEF ORGANIZATION MANAGEMENT"
     banner "knife opc org show ORGNAME"
 
+    include Chef::Mixin::RootRestv0
+
     def run
       org_name = @name_args[0]
-      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
-      ui.output @chef_rest.get_rest("organizations/#{org_name}")
+      ui.output root_rest.get("organizations/#{org_name}")
     end
   end
 end

--- a/lib/chef/knife/opc_user_create.rb
+++ b/lib/chef/knife/opc_user_create.rb
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'chef/mixin/root_rest'
 
 module Opc
   class OpcUserCreate < Chef::Knife
@@ -30,6 +31,8 @@ module Opc
     :long => '--orgname ORGNAME',
     :short => '-o ORGNAME',
     :description => 'Associate new user to an organization matching ORGNAME'
+
+    include Chef::Mixin::RootRestv0
 
     def run
       case @name_args.count
@@ -63,8 +66,7 @@ module Opc
        end
      end
 
-      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
-      result = @chef_rest.post_rest("users/", user_hash)
+      result = root_rest.post("users/", user_hash)
       if config[:filename]
         File.open(config[:filename], "w") do |f|
           f.print(result['private_key'])
@@ -74,9 +76,9 @@ module Opc
       end
       if config[:orgname]
         request_body = {:user => username}
-        response = @chef_rest.post_rest "organizations/#{config[:orgname]}/association_requests", request_body
+        response = root_rest.post("organizations/#{config[:orgname]}/association_requests", request_body)
         association_id = response["uri"].split("/").last
-        @chef_rest.put_rest "users/#{username}/association_requests/#{association_id}", { :response => 'accept' }
+        root_rest.put("users/#{username}/association_requests/#{association_id}", {:response => 'accept'})
       end
     end
   end

--- a/lib/chef/knife/opc_user_delete.rb
+++ b/lib/chef/knife/opc_user_delete.rb
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'chef/mixin/root_rest'
 
 module Opc
   class OpcUserDelete < Chef::Knife
@@ -26,18 +27,19 @@ module Opc
     :short => "-d",
     :description => "Don't disassociate the user first"
 
+    include Chef::Mixin::RootRestv0
+
     def run
       username = @name_args[0]
-      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
       ui.confirm "Do you want to delete the user #{username}"
       unless config[:no_disassociate_user]
-         orgs =  @chef_rest.get_rest("users/#{username}/organizations")
+         orgs =  root_rest.get("users/#{username}/organizations")
          org_names = orgs.map {|o| o['organization']['name']}
          org_names.each do |org|
-            ui.output @chef_rest.delete_rest("organizations/#{org}/users/#{username}")
+            ui.output root_rest.delete("organizations/#{org}/users/#{username}")
          end
       end
-      ui.output @chef_rest.delete_rest("users/#{username}")
+      ui.output root_rest.delete("users/#{username}")
     end
   end
 end

--- a/lib/chef/knife/opc_user_show.rb
+++ b/lib/chef/knife/opc_user_show.rb
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'chef/mixin/root_rest'
 
 module Opc
   class OpcUserShow < Chef::Knife
@@ -25,12 +26,13 @@ module Opc
     :long => "--with-orgs",
     :short => "-l"
 
+    include Chef::Mixin::RootRestv0
+
     def run
       user_name = @name_args[0]
-      @chef_rest = Chef::REST.new(Chef::Config[:chef_server_root])
-      results =  @chef_rest.get_rest("users/#{user_name}")
+      results =  root_rest.get("users/#{user_name}")
       if config[:with_orgs]
-        orgs =  @chef_rest.get_rest("users/#{user_name}/organizations")
+        orgs =  root_rest.get("users/#{user_name}/organizations")
         results["organizations"] = orgs.map {|o| o['organization']['name']}
       end
       ui.output results

--- a/lib/chef/mixin/root_rest.rb
+++ b/lib/chef/mixin/root_rest.rb
@@ -1,6 +1,6 @@
 #
-# Author:: Steven Danna (<steve@opscode.com>)
-# Copyright:: Copyright 2011 Opscode, Inc.
+# Author:: Steven Danna (<steve@chef.io>)
+# Copyright:: Copyright 2011 Chef Software, Inc
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,23 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'chef/mixin/root_rest'
-
-module Opc
-  class OpcUserList < Chef::Knife
-    category "OPSCODE PRIVATE CHEF ORGANIZATION MANAGEMENT"
-    banner "knife opc user list"
-
-    option :with_uri,
-    :long => "--with-uri",
-    :short => "-w",
-    :description => "Show corresponding URIs"
-
-    include Chef::Mixin::RootRestv0
-
-    def run
-      results = root_rest.get("users")
-      ui.output(ui.format_list_for_display(results))
+require 'chef/server_api'
+class Chef
+  module Mixin
+    module RootRestv0
+      def root_rest
+        # Use v0 API for now
+        # Rather than upgrade all of this code to move to v1, the goal is to remove the
+        # need for this plugin.  See
+        # https://github.com/chef/chef/issues/3517
+        @root_rest ||= Chef::ServerAPI.new(Chef::Config[:chef_server_root], {:api_version => "0"})
+      end
     end
   end
 end

--- a/spec/unit/opc_org_list_spec.rb
+++ b/spec/unit/opc_org_list_spec.rb
@@ -11,9 +11,9 @@ describe Opc::OpcOrgList do
   end
 
   before :each do
-    @rest = double('Chef::REST')
-    allow(Chef::REST).to receive(:new).and_return(@rest)
-    allow(@rest).to receive(:get_rest).with('organizations').and_return(orgs)
+    @rest = double('Chef::ServerAPI')
+    allow(Chef::ServerAPI).to receive(:new).and_return(@rest)
+    allow(@rest).to receive(:get).with('organizations').and_return(orgs)
     @knife = Chef::Knife::OpcOrgList.new
   end
 


### PR DESCRIPTION
The newest versions of the Chef Server present new behavior for the
user endpoints. Code to handle this new behavior has been added to
core chef. Rather than replicate all that code here, we can use
Chef::ServerAPI to use the v0 API.

The goal is to move all of this plugin into core Chef before v0 is
deprecated.