### PR TITLE
SPOOL-321 - handling admin group membership in delete-user 

### DIFF
--- a/lib/chef/knife/opc_user_delete.rb
+++ b/lib/chef/knife/opc_user_delete.rb
@@ -19,27 +19,145 @@ require 'chef/mixin/root_rest'
 
 module Opc
   class OpcUserDelete < Chef::Knife
+  class DeleteFailed < StandardError ; end
     category "OPSCODE PRIVATE CHEF ORGANIZATION MANAGEMENT"
-    banner "knife opc user delete USERNAME [-d]"
+    banner "knife opc user delete USERNAME [-d] [-R]"
 
     option :no_disassociate_user,
-    :long => "--no-disassociate-user",
-    :short => "-d",
-    :description => "Don't disassociate the user first"
+      :long => "--no-disassociate-user",
+      :short => "-d",
+      :description => "Don't disassociate the user first"
 
+    option :remove_from_admin_groups,
+      long:  "--remove-from-admin-groups",
+      short:  "-R",
+      description: "If the user is a member of any org admin groups, attempt to remove from those groups. Ignored if --no-disassociate-user is set."
+
+    attr_reader :username
     include Chef::Mixin::RootRestv0
 
+    deps do
+      require 'chef/org'
+      require 'chef/org/group_operations'
+    end
+
     def run
-      username = @name_args[0]
+      @username = @name_args[0]
+      admin_memberships = []
+      unremovable_memberships = []
+
       ui.confirm "Do you want to delete the user #{username}"
-      unless config[:no_disassociate_user]
-         orgs =  root_rest.get("users/#{username}/organizations")
-         org_names = orgs.map {|o| o['organization']['name']}
-         org_names.each do |org|
-            ui.output root_rest.delete("organizations/#{org}/users/#{username}")
-         end
+
+      if config[:no_disassociate_user]
+        delete_user(username)
+        return
       end
+
+      ui.output("Checking organization memberships...")
+      orgs = org_memberships(username)
+
+      if orgs.length > 0
+        ui.output("Checking admin group memberships for #{orgs.length} org(s).")
+        admin_memberships, unremovable_memberships = admin_group_memberships(orgs, username)
+      end
+
+      if admin_memberships.empty?
+        disassociate_user(orgs, username)
+        delete_user(username)
+      else # Has admin memberships:
+        if config[:remove_from_admin_groups]
+          unless unremovable_memberships.empty?
+            raise DeleteFailed.new(error_cant_remove_admin_membership(username, unremovable_memberships))
+          end
+          remove_from_admin_groups(admin_memberships, username)
+        else
+          raise DeleteFailed.new(error_admin_group_member(username,
+                                                          admin_memberships))
+        end
+        disassociate_user(orgs, username)
+        delete_user(username)
+      end
+    rescue DeleteFailed => e
+      ui.output(e.message)
+    end
+
+    def disassociate_user(orgs, username)
+      orgs.each  {|org| org.dissociate_user(username) }
+    end
+
+    def org_memberships(username)
+      org_data =  root_rest.get("users/#{username}/organizations")
+      org_names = org_data.map {|o| o['organization']['name']}
+      orgs = []
+      org_names.each { |name| orgs << Chef::Org.new(name) }
+      orgs
+    end
+
+    def remove_from_admin_groups(admin_of, username)
+      admin_of.each { |org| org.remove_user_from_group("admins", username) }
+    end
+
+    def admin_group_memberships(orgs, username)
+      admin_of = []
+      unremovable = []
+      orgs.each do |org|
+        if org.user_member_of_group?(username, 'admins')
+          admin_of << org
+          if org.actor_delete_would_leave_admins_empty?
+            unremovable << org
+          end
+        end
+      end
+      [admin_of, unremovable]
+    end
+
+    def delete_user(username)
       ui.output root_rest.delete("users/#{username}")
+    end
+    def pluralize(word, quantity)
+      case word
+      when "it"
+        quantity > 1 ? "them" : "it"
+      else
+        quantity == 1 ? word : "#{word}s"
+      end
+    end
+
+
+    # Error message that says how to removed from org
+    # admin groups before deleting
+    # Further
+    def error_admin_group_member(username, admin_of)
+      message = "#{username} is in the 'admins' group of the following organization(s):\n\n"
+
+      admin_of.each { |org| message << "- #{org.name}\n" }
+
+      message << <<EOM
+
+Run this command again with the --remove-from-admin-groups option to
+remove the user from these admin group(s) automatically.
+
+EOM
+      message
+    end
+
+    def error_cant_remove_admin_membership(username, only_admin_of)
+      message = <<EOM
+
+#{username} is the only member of the 'admins' group of the
+following organization(s):
+
+EOM
+        only_admin_of.each {|org| message <<  "- #{org.name}\n"}
+
+        message << <<EOM
+
+Removing the only administrator of an organization can break it.
+Assign additional users or groups to the admin group(s) before
+deleting this user.
+
+EOM
+      message
     end
   end
 end

--- a/lib/chef/org/group_operations.rb
+++ b/lib/chef/org/group_operations.rb
@@ -48,7 +48,7 @@ class Chef
             admins['actors'].length <= 1
           end
         else
-          # We don't  check recursively. If the admins group contains a group,
+          # We don't check recursively. If the admins group contains a group,
           # and the user is the only member of that group,
           # we'll still turn up a 'safe to delete'.
           false

--- a/lib/chef/org/group_operations.rb
+++ b/lib/chef/org/group_operations.rb
@@ -3,8 +3,18 @@ require 'chef/org'
 class Chef
   class Org
     module GroupOperations
+      def group(groupname)
+        @group ||= {}
+        @group[groupname] ||= chef_rest.get_rest "organizations/#{name}/groups/#{groupname}"
+      end
+
+      def user_member_of_group?(username, groupname)
+        group = group(groupname)
+        group['actors'].include? username
+      end
+
       def add_user_to_group(groupname, username)
-        group = chef_rest.get_rest "organizations/#{name}/groups/#{groupname}"
+        group = group(groupname)
         body_hash = {
           :groupname => "#{groupname}",
           :actors => {
@@ -16,7 +26,7 @@ class Chef
       end
 
       def remove_user_from_group(groupname, username)
-        group = chef_rest.get_rest "organizations/#{name}/groups/#{groupname}"
+        group = group(groupname)
         group['actors'].delete(username)
         body_hash = {
           :groupname => "#{groupname}",
@@ -29,10 +39,20 @@ class Chef
       end
 
       def actor_delete_would_leave_admins_empty?
-        group = chef_rest.get_rest "organizations/#{name}/groups/admins"
-        # pivotal should not factor into this check
-        group['actors'].delete('pivotal')
-        group['actors'].length <= 1 && group['groups'].empty?
+        admins = group('admins')
+        if admins['groups'].empty?
+          # exclude 'pivotal' but don't mutate the group since we're caching it
+          if admins['actors'].include? "pivotal"
+            admins['actors'].length <= 2
+          else
+            admins['actors'].length <= 1
+          end
+        else
+          # We don't  check recursively. If the admins group contains a group,
+          # and the user is the only member of that group,
+          # we'll still turn up a 'safe to delete'.
+          false
+        end
       end
     end
     include Chef::Org::GroupOperations

--- a/spec/unit/org_group_spec.rb
+++ b/spec/unit/org_group_spec.rb
@@ -1,0 +1,48 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef/org'
+require 'chef/org/group_operations'
+
+describe Chef::Org do
+  before(:each) do
+    @org = Chef::Org.new("myorg")
+  end
+
+  describe "API Interactions" do
+    before(:each) do
+      Chef::Config[:chef_server_root] = "http://www.example.com"
+      @rest = double('rest')
+      allow(Chef::REST).to receive(:new).and_return(@rest)
+    end
+
+    describe "group" do
+      it "should load group data when it's not loaded." do
+        expect(@rest).to receive(:get_rest).with("organizations/myorg/groups/admins").and_return({ })
+        @org.group("admins")
+      end
+
+      it "should not load group data a second time when it's already loaded." do
+        expect(@rest).to receive(:get_rest).
+          with("organizations/myorg/groups/admins").
+          and_return({ anything: "goes" }).
+          exactly(:once)
+        admin1 = @org.group("admins")
+        admin2 = @org.group("admins")
+        expect(admin1).to eq admin2
+      end
+    end
+  end
+end

--- a/spec/unit/org_group_spec.rb
+++ b/spec/unit/org_group_spec.rb
@@ -17,9 +17,7 @@ require 'chef/org'
 require 'chef/org/group_operations'
 
 describe Chef::Org do
-  before(:each) do
-    @org = Chef::Org.new("myorg")
-  end
+  let(:org) { Chef::Org.new("myorg") }
 
   describe "API Interactions" do
     before(:each) do
@@ -31,7 +29,7 @@ describe Chef::Org do
     describe "group" do
       it "should load group data when it's not loaded." do
         expect(@rest).to receive(:get_rest).with("organizations/myorg/groups/admins").and_return({ })
-        @org.group("admins")
+        org.group("admins")
       end
 
       it "should not load group data a second time when it's already loaded." do
@@ -39,8 +37,8 @@ describe Chef::Org do
           with("organizations/myorg/groups/admins").
           and_return({ anything: "goes" }).
           exactly(:once)
-        admin1 = @org.group("admins")
-        admin2 = @org.group("admins")
+        admin1 = org.group("admins")
+        admin2 = org.group("admins")
         expect(admin1).to eq admin2
       end
     end

--- a/spec/unit/user_delete_spec.rb
+++ b/spec/unit/user_delete_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+require 'chef/org'
+require 'chef/org/group_operations'
+require "chef/knife/opc_user_delete"
+
+describe Opc::OpcUserDelete do
+  subject(:knife) { Chef::Knife::OpcUserDelete.new }
+
+  let(:non_admin_member_org) { Chef::Org.new("non-admin-member")}
+  let(:solo_admin_member_org) { Chef::Org.new("solo-admin-member")}
+  let(:shared_admin_member_org) { Chef::Org.new("shared-admin-member") }
+
+  let(:removable_orgs) { [non_admin_member_org, shared_admin_member_org] }
+  let(:non_removable_orgs) { [solo_admin_member_org] }
+
+  let(:admin_memberships) { [ removable_orgs, non_removable_orgs ] }
+  let(:username) { "test_user" }
+
+  let(:rest) { double("Chef::ServerAPI") }
+  let(:orgs) { [non_admin_member_org, solo_admin_member_org, shared_admin_member_org] }
+  let(:knife) { Chef::Knife::OpcUserDelete.new }
+
+  let(:orgs_data) {
+    [{"organization" => { "name" => "non-admin-member" }},
+     {"organization" => { "name" => "solo-admin-member" }},
+     {"organization" => { "name" => "shared-admin-member" }}
+  ]
+  }
+
+  before(:each) do
+    allow(Chef::ServerAPI).to receive(:new).and_return(rest)
+    knife.name_args << username
+    knife.config[:yes] = true
+  end
+
+  context "when invoked" do
+    before do
+      allow(knife).to receive(:admin_group_memberships).and_return(admin_memberships)
+    end
+
+    context "with --no-disassociate-user" do
+      before(:each) do
+        knife.config[:no_disassociate_user] = true
+      end
+
+      it "should bypass all checks and go directly to user deletion" do
+        expect(knife).to receive(:delete_user).with(username)
+        knife.run
+      end
+    end
+
+    context "without --no-disassociate-user" do
+      before do
+        allow(knife).to receive(:org_memberships).and_return(orgs)
+      end
+
+
+      context "and with --remove-from-admin-groups" do
+        let(:non_removable_orgs) { [ solo_admin_member_org ] }
+        before(:each) do
+          knife.config[:remove_from_admin_groups] = true
+        end
+
+        context "when an associated user the only organization admin" do
+          let(:non_removable_orgs) { [ solo_admin_member_org ] }
+
+          it "refuses to proceed with because the user is the only admin" do
+            expect(knife).to receive(:error_exit_cant_remove_admin_membership!).and_call_original
+            expect {knife.run}.to raise_error SystemExit
+          end
+        end
+
+        context "when an associated user is one of many organization admins" do
+          let(:non_removable_orgs) { [] }
+
+          it "should remove the user from the group, the org, and then and delete the user" do
+            expect(knife).to receive(:disassociate_user)
+            expect(knife).to receive(:remove_from_admin_groups)
+            expect(knife).to receive(:delete_user)
+            expect(knife).to receive(:error_exit_cant_remove_admin_membership!).exactly(0).times
+            expect(knife).to receive(:error_exit_admin_group_member!).exactly(0).times
+            knife.run
+          end
+
+        end
+      end
+
+      context "and without --remove-from-admin-groups" do
+        before(:each) do
+          knife.config[:remove_from_admin_groups] = false
+        end
+
+        context "when an associated user is in admins group" do
+          let(:removable_orgs) { [ shared_admin_member_org ] }
+          let(:non_removable_orgs) { [ ] }
+          it "refuses to proceed with because the user is an admin" do
+            # Default setup
+            expect(knife).to receive(:error_exit_admin_group_member!).and_call_original
+            expect { knife.run }.to raise_error SystemExit
+          end
+        end
+      end
+
+    end
+    context "without --remove-from-admin-groups" do
+
+    end
+
+  end
+
+  context "#admin_group_memberships" do
+    before do
+      expect(non_admin_member_org).to receive(:user_member_of_group?).and_return false
+
+      expect(solo_admin_member_org).to receive(:user_member_of_group?).and_return true
+      expect(solo_admin_member_org).to receive(:actor_delete_would_leave_admins_empty?).and_return true
+
+      expect(shared_admin_member_org).to receive(:user_member_of_group?).and_return true
+      expect(shared_admin_member_org).to receive(:actor_delete_would_leave_admins_empty?).and_return false
+
+    end
+
+    it "returns an array of organizations in which the user is an admin, and an array of orgs which block removal"  do
+      expect(knife.admin_group_memberships(orgs, username)).to eq [ [solo_admin_member_org, shared_admin_member_org], [solo_admin_member_org]]
+    end
+  end
+
+  context "#delete_user" do
+    it "attempts to delete the user from the system via DELETE to the /users endpoint" do
+      expect(rest).to receive(:delete).with("users/#{username}")
+      knife.delete_user(username)
+    end
+  end
+
+  context "#disassociate_user" do
+    it "attempts to remove dissociate the user from each org" do
+      removable_orgs.each { |org| expect(org).to receive(:dissociate_user).with(username) }
+      knife.disassociate_user(removable_orgs, username)
+    end
+  end
+
+  context "#remove_from_admin_groups" do
+    it "attempts to remove the given user from the organizations' groups" do
+      removable_orgs.each { |org| expect(org).to receive(:remove_user_from_group).with("admins", username) }
+      knife.remove_from_admin_groups(removable_orgs, username)
+    end
+  end
+
+  context "#org_memberships" do
+    it "should make a REST request to return the list of organizations that the user is a member of" do
+      expect(rest).to receive(:get).with("users/test_user/organizations").and_return orgs_data
+      result = knife.org_memberships(username)
+      result.each_with_index do |v, x|
+        expect(v.to_hash).to eq(orgs[x].to_hash)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This PR modifies knife-opc-delete-user in a couple of ways: 

1. report back to the user which orgs are blocking deletion 
2. give the option --remove-from-admin-groups to automatically remove  the user to be deleted from the admin group(s). 
3. when removing the user from admin group(s) would result in an empty admin group, refuse to do so.

In all of the cases above, if group membership will prevent further activity, no actions are taken to ensure that we don't apply a partial change. 

The behavior of `delete user` when the `--no-disassociate-user` flag is passed is unchanged - it will delete the user from the system without disassociating the user from any organizations, or removing from any org admin groups. 

TODO: 

* [x] the opc-delete-user command doesn't currently have coverage. I'll be adding a spec for that, covering new/old functionality. 