### PR TITLE
Don't print the user object after password update

### DIFF
--- a/lib/chef/knife/opc_user_password.rb
+++ b/lib/chef/knife/opc_user_password.rb
@@ -65,7 +65,7 @@ module Opc
       rescue => e
         raise e
       end
-      ui.msg user
+
       ui.msg("Authentication info updated for #{user_name}.")
     end
   end


### PR DESCRIPTION
This will echo the password to the screen, see:

   chef/chef-server#748

Signed-off-by: Steven Danna <steve@chef.io>