### PR TITLE
[SUSTAIN-784] Option for pw prompt on user create

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ Show a list of all users in your OPC installation.
 
 Shows the details of a user in your OPC installation.
 
-### knife opc user create USERNAME FIRST_NAME [MIDDLE_NAME] LAST_NAME EMAIL PASSWORD (options)
+### knife opc user create USERNAME FIRST_NAME [MIDDLE_NAME] LAST_NAME EMAIL [PASSWORD] (options)
 
 - `-f FILENAME`, `--filename FILENAME`: Write private key to FILENAME rather than STDOUT.
+- `-p`, `--prompt-for-password`: Prompt for password rather than providing it on the command line.
 
 Creates a new user in your OPC installation. The user's private key will be returned in response. Without this key, the user will need to log into the WebUI and regenerate their key before they can use knife.
 

--- a/lib/chef/knife/opc_org_user_remove.rb
+++ b/lib/chef/knife/opc_org_user_remove.rb
@@ -87,17 +87,15 @@ EOF
     end
 
     def remove_user_from_admin_group(org, org_name, username, admin_group_string)
-      begin
-        org.remove_user_from_group(admin_group_string, username)
-      rescue Net::HTTPServerException => e
-        if e.response.code == "404"
-          ui.warn <<-EOF
+      org.remove_user_from_group(admin_group_string, username)
+    rescue Net::HTTPServerException => e
+      if e.response.code == "404"
+        ui.warn <<-EOF
 User #{username} is not in the #{admin_group_string} group for organization #{org_name}.
 You probably don't need to pass --force.
 EOF
-        else
-          raise e
-        end
+      else
+        raise e
       end
     end
 

--- a/lib/chef/knife/opc_user_create.rb
+++ b/lib/chef/knife/opc_user_create.rb
@@ -32,6 +32,11 @@ module Opc
     :short => "-o ORGNAME",
     :description => "Associate new user to an organization matching ORGNAME"
 
+    option :passwordprompt,
+    :long => "--prompt-for-password",
+    :short => "-p",
+    :description => "Prompt for user password"
+
     include Chef::Mixin::RootRestv0
 
     def run
@@ -40,9 +45,16 @@ module Opc
         username, first_name, middle_name, last_name, email, password = @name_args
       when 5
         username, first_name, last_name, email, password = @name_args
+      when 4
+        username, first_name, last_name, email = @name_args
       else
         ui.fatal "Wrong number of arguments"
         show_usage
+        exit 1
+      end
+      password = prompt_for_password if config[:passwordprompt]
+      unless password
+        ui.fatal "You must either provide a password or use the --prompt-for-password (-p) option"
         exit 1
       end
       middle_name ||= ""
@@ -80,6 +92,10 @@ module Opc
         association_id = response["uri"].split("/").last
         root_rest.put("users/#{username}/association_requests/#{association_id}", { :response => "accept" })
       end
+    end
+
+    def prompt_for_password
+      ui.ask("Please enter the user's password: ") { |q| q.echo = false }
     end
   end
 end

--- a/spec/unit/org_group_spec.rb
+++ b/spec/unit/org_group_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Org do
     before(:each) do
       Chef::Config[:chef_server_root] = "http://www.example.com"
       @rest = double("rest")
-      allow(Chef::REST).to receive(:new).and_return(@rest)
+      allow(Chef::ServerAPI).to receive(:new).and_return(@rest)
     end
 
     describe "group" do

--- a/spec/unit/org_spec.rb
+++ b/spec/unit/org_spec.rb
@@ -138,7 +138,7 @@ describe Chef::Org do
     before (:each) do
       Chef::Config[:chef_server_root] = "http://www.example.com"
       @rest = double("rest")
-      allow(Chef::REST).to receive(:new).and_return(@rest)
+      allow(Chef::ServerAPI).to receive(:new).and_return(@rest)
       @org = Chef::Org.new
       @org.name "foobar"
       @org.full_name "foo bar bat"


### PR DESCRIPTION
This adds an option to the `user create` subcommand to allow the user to
be prompted for the password rather than requiring it at the command
line.  This gives users the ability to keep passwords out of shell
history.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>