### PR TITLE
Bump to 0.4.0

### DIFF
--- a/lib/knife-opc/version.rb
+++ b/lib/knife-opc/version.rb
@@ -1,3 +1,3 @@
 module KnifeOPC
-  VERSION = "0.3.2"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
We've not been bumping the version since most consumers grab master as part of their packaging. However travis likes to use the rubygems version, and that's causing failures with newer versions of chef.

Signed-off-by: Mark Anderson <mark@chef.io>