### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/opc_org_create.rb
+++ b/lib/chef/knife/opc_org_create.rb
@@ -34,8 +34,8 @@ module Opc
     attr_accessor :org_name, :org_full_name
 
     deps do
-      require "chef/org"
-      require "chef/org/group_operations"
+      require_relative "../org"
+      require_relative "../org/group_operations"
     end
 
     def run

--- a/lib/chef/knife/opc_org_delete.rb
+++ b/lib/chef/knife/opc_org_delete.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcOrgDelete < Chef::Knife

--- a/lib/chef/knife/opc_org_edit.rb
+++ b/lib/chef/knife/opc_org_edit.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcOrgEdit < Chef::Knife

--- a/lib/chef/knife/opc_org_list.rb
+++ b/lib/chef/knife/opc_org_list.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcOrgList < Chef::Knife

--- a/lib/chef/knife/opc_org_show.rb
+++ b/lib/chef/knife/opc_org_show.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcOrgShow < Chef::Knife

--- a/lib/chef/knife/opc_org_user_add.rb
+++ b/lib/chef/knife/opc_org_user_add.rb
@@ -28,8 +28,8 @@ module Opc
       description: "Add user to admin group"
 
     deps do
-      require "chef/org"
-      require "chef/org/group_operations"
+      require_relative "../org"
+      require_relative "../org/group_operations"
     end
 
     def run

--- a/lib/chef/knife/opc_org_user_remove.rb
+++ b/lib/chef/knife/opc_org_user_remove.rb
@@ -28,8 +28,8 @@ module Opc
       description: "Force removal of user from the organization's admins and billing-admins group."
 
     deps do
-      require "chef/org"
-      require "chef/org/group_operations"
+      require_relative "../org"
+      require_relative "../org/group_operations"
       require "chef/json_compat"
     end
 

--- a/lib/chef/knife/opc_user_create.rb
+++ b/lib/chef/knife/opc_user_create.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcUserCreate < Chef::Knife

--- a/lib/chef/knife/opc_user_delete.rb
+++ b/lib/chef/knife/opc_user_delete.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcUserDelete < Chef::Knife
@@ -36,8 +36,8 @@ module Opc
     include Chef::Mixin::RootRestv0
 
     deps do
-      require "chef/org"
-      require "chef/org/group_operations"
+      require_relative "../org"
+      require_relative "../org/group_operations"
     end
 
     def run

--- a/lib/chef/knife/opc_user_edit.rb
+++ b/lib/chef/knife/opc_user_edit.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcUserEdit < Chef::Knife

--- a/lib/chef/knife/opc_user_list.rb
+++ b/lib/chef/knife/opc_user_list.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcUserList < Chef::Knife

--- a/lib/chef/knife/opc_user_password.rb
+++ b/lib/chef/knife/opc_user_password.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcUserPassword < Chef::Knife

--- a/lib/chef/knife/opc_user_show.rb
+++ b/lib/chef/knife/opc_user_show.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/mixin/root_rest"
+require_relative "../mixin/root_rest"
 
 module Opc
   class OpcUserShow < Chef::Knife

--- a/lib/chef/org.rb
+++ b/lib/chef/org.rb
@@ -1,7 +1,7 @@
 require "chef/json_compat"
 require "chef/mixin/params_validate"
 require "chef/server_api"
-require "chef/org/group_operations"
+require_relative "org/group_operations"
 
 class Chef
   class Org

--- a/lib/chef/org/group_operations.rb
+++ b/lib/chef/org/group_operations.rb
@@ -1,4 +1,4 @@
-require "chef/org"
+require_relative "../org"
 
 class Chef
   class Org


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>