### PR TITLE
OPC user edit throwing hydrate errors fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ Creates a new user in your OPC installation. The user's private key will be retu
 
 Deletes the given OPC user.
 
-### knife opc user edit USERNAME
+### knife opc user edit USERNAME (options)
+
+- `-i FILENAME`, `--input FILENAME`: Will read the user information (i.e. username, email, display_name, first_name, last_name, middle_name) from the input FILENAME and update the given OPC user.
+- `-f FILENAME`, `--filename FILENAME`: Open FILENAME on $EDITOR. When finished, Updates the given OPC user.
 
 Will open $EDITOR. When finished, Knife will update the given OPC user.
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Deletes the given OPC user.
 
 ### knife opc user edit USERNAME (options)
 
-- `-i FILENAME`, `--input FILENAME`: Reads the user information (`username`, `email`, `display_name`, `first_name`, `last_name`, `middle_name`) from the input FILENAME and updates the given OPC user.
-- `-f FILENAME`, `--filename FILENAME`: Opens FILENAME in $EDITOR. Updates the given OPC user when the file is saved. This file is expected to be in the json format.
+- `-i FILENAME`, `--input FILENAME`: Reads the user information (`username`, `email`, `display_name`, `first_name`, `last_name`, `middle_name`) from the input FILENAME and updates the given OPC user. This file is expected to be in the json format.
 
 ### For example:
+
 ```
 {
   "username": "test",
@@ -99,6 +99,8 @@ Deletes the given OPC user.
   "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9wXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nPukZaQcKSo4lnF9mMXXXXXXXXXXXXX7nKKRCaS5ranjsaQXeTJA\nLdFLYuL46XiUXXXXXXXXXXXXXXXXXGRwCrAnVyz0iSuNH7\nr9OZaWm+iVaHReFLleNT+CNuNXXXXXXXXXXXXXXXXXXwv9TFLCGiJyzzk\nhLnvgj8n39JtXiC6lIRXXXXXXXXX/ccd3yQusczFreQ\nyDcW+4HS9B6eLyNH1ty9IcFVbL4P4L/kKPHtzkXXXXXXXXXXXXXinPA\nYQIDAQAB\n-----END PUBLIC KEY-----\n\n"
 }
 ```
+
+- `-f FILENAME`, `--filename FILENAME`: Opens FILENAME in $EDITOR. Updates the given OPC user when the file is saved.
 
 Will open $EDITOR. When finished, Knife will update the given OPC user.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Deletes the given OPC user.
 
 ### knife opc user edit USERNAME (options)
 
-- `-i FILENAME`, `--input FILENAME`: Reads the user information (`username`, `email`, `display_name`, `first_name`, `last_name`, `middle_name`) from the input FILENAME and updates the given OPC user. This file is expected to be in the json format.
+- `-i FILENAME`, `--input FILENAME`: Reads the user information (`username`, `email`, `display_name`, `first_name`, `last_name`, `middle_name`) from the input FILENAME and updates the given OPC user. Knife will accept a JSON file.
 
 ### For example:
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Deletes the given OPC user.
 
 ### knife opc user edit USERNAME (options)
 
-- `-i FILENAME`, `--input FILENAME`: Will read the user information (i.e. username, email, display_name, first_name, last_name, middle_name) from the input FILENAME and update the given OPC user.
-- `-f FILENAME`, `--filename FILENAME`: Open FILENAME on $EDITOR. When finished, Updates the given OPC user.
+- `-i FILENAME`, `--input FILENAME`: Reads the user information (`username`, `email`, `display_name`, `first_name`, `last_name`, `middle_name`) from the input FILENAME and updates the given OPC user.
+- `-f FILENAME`, `--filename FILENAME`: Opens FILENAME in $EDITOR. Updates the given OPC user when the file is saved.
 
 Will open $EDITOR. When finished, Knife will update the given OPC user.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,20 @@ Deletes the given OPC user.
 ### knife opc user edit USERNAME (options)
 
 - `-i FILENAME`, `--input FILENAME`: Reads the user information (`username`, `email`, `display_name`, `first_name`, `last_name`, `middle_name`) from the input FILENAME and updates the given OPC user.
-- `-f FILENAME`, `--filename FILENAME`: Opens FILENAME in $EDITOR. Updates the given OPC user when the file is saved.
+- `-f FILENAME`, `--filename FILENAME`: Opens FILENAME in $EDITOR. Updates the given OPC user when the file is saved. This file is expected to be in the json format.
+
+### For example:
+```
+{
+  "username": "test",
+  "email": "testb@exampl.com",
+  "display_name": "test abc",
+  "first_name": "test",
+  "last_name": "abc",
+  "middle_name": "",
+  "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9wXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nPukZaQcKSo4lnF9mMXXXXXXXXXXXXX7nKKRCaS5ranjsaQXeTJA\nLdFLYuL46XiUXXXXXXXXXXXXXXXXXGRwCrAnVyz0iSuNH7\nr9OZaWm+iVaHReFLleNT+CNuNXXXXXXXXXXXXXXXXXXwv9TFLCGiJyzzk\nhLnvgj8n39JtXiC6lIRXXXXXXXXX/ccd3yQusczFreQ\nyDcW+4HS9B6eLyNH1ty9IcFVbL4P4L/kKPHtzkXXXXXXXXXXXXXinPA\nYQIDAQAB\n-----END PUBLIC KEY-----\n\n"
+}
+```
 
 Will open $EDITOR. When finished, Knife will update the given OPC user.
 

--- a/lib/chef/knife/opc_user_edit.rb
+++ b/lib/chef/knife/opc_user_edit.rb
@@ -82,6 +82,7 @@ module Opc
             f.puts output
             f.close
             raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_setup/ for details." unless system("#{config[:editor]} #{f.path}")
+
             edited_user = JSON.parse(IO.read(f.path))
           end
         end


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

### Description
- Fixed `knife opc user edit USERNAME`
- Fixed `knife opc user edit USERNAME -f FILENAME`

### Issues Resolved
#53
https://github.com/chef/chef-workstation/issues/1167 
https://github.com/chef/chef-workstation/issues/1179#issuecomment-629321414

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG