### PR TITLE
Added all_info option to retrieve more than just username in opc user list

### DIFF
--- a/lib/chef/knife/opc_user_list.rb
+++ b/lib/chef/knife/opc_user_list.rb
@@ -37,24 +37,11 @@ module Opc
     def run
       if config[:all_info]
         results = root_rest.get("users?verbose=true")
-        ui.output format_user_list(results)
+        ui.output results
       else
         results = root_rest.get("users")
         ui.output(ui.format_list_for_display(results))
       end
-    end
-
-    private
-
-    def format_user_list(users)
-      final_list = []
-      users.each do |username, user_info|
-        user_list = {}
-        user_list[:username] = username
-        user_list = user_list.merge(user_info)
-        final_list.push(user_list)
-      end
-      final_list
     end
   end
 end

--- a/lib/chef/knife/opc_user_list.rb
+++ b/lib/chef/knife/opc_user_list.rb
@@ -27,11 +27,35 @@ module Opc
       short: "-w",
       description: "Show corresponding URIs"
 
+    option :all_info,
+      long: "--all-info",
+      short: "-a",
+      description: "Show corresponding details i.e. username, email, first_name, last_name, display_name"
+
+
     include Chef::Mixin::RootRestv0
 
     def run
-      results = root_rest.get("users")
-      ui.output(ui.format_list_for_display(results))
+      if config[:all_info]
+        results = root_rest.get("users?verbose=true")
+        ui.output format_user_list(results)
+      else
+        results = root_rest.get("users")
+        ui.output(ui.format_list_for_display(results))
+      end
+    end
+
+    private
+
+    def format_user_list(users)
+      final_list = []
+      users.each do |username, user_info|
+        user_list = {}
+        user_list[:username] = username
+        user_list = user_list.merge(user_info)
+        final_list.push(user_list)
+      end
+      return final_list
     end
   end
 end

--- a/lib/chef/knife/opc_user_list.rb
+++ b/lib/chef/knife/opc_user_list.rb
@@ -32,7 +32,6 @@ module Opc
       short: "-a",
       description: "Show corresponding details i.e. username, email, first_name, last_name, display_name"
 
-
     include Chef::Mixin::RootRestv0
 
     def run
@@ -55,7 +54,7 @@ module Opc
         user_list = user_list.merge(user_info)
         final_list.push(user_list)
       end
-      return final_list
+      final_list
     end
   end
 end

--- a/spec/unit/user_list_spec.rb
+++ b/spec/unit/user_list_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+require "chef/knife/opc_user_list"
+
+describe Opc::OpcUserList do
+
+  let(:users) do
+    {
+     "test_user1" => {
+        "email": "test_user1@example.com",
+        "first_name": "Test",
+        "last_name": "User1",
+        "display_name": "Test User1"
+      },
+      "test_user2" => {
+        "email": "agupta@example.com",
+        "first_name": "Test",
+        "last_name": "User2",
+        "display_name": "Test User2"
+      }
+
+    }
+  end
+
+  before :each do
+    @rest = double("Chef::ServerAPI")
+    allow(Chef::ServerAPI).to receive(:new).and_return(@rest)
+    allow(@rest).to receive(:get).with("users").and_return(users)
+    @knife = Chef::Knife::OpcUserList.new
+  end
+
+  describe "with no arguments" do
+    it "lists all user" do
+      expect(@knife.ui).to receive(:output).with(%w{test_user1 test_user2})
+      @knife.run
+    end
+  end
+
+  describe "list user with_uri argument" do
+    let(:users) do
+      {
+       "test_user1" =>  "https://example.com/organizations/test_org1/users/test_user1",
+       "test_user2" => "https://example.com/organizations/test_org2/users/test_user2"
+      }
+    end
+
+    before do
+      @knife.config[:with_uri] = true
+    end
+
+    it "lists all user with corresponding URIs" do
+      expect(@knife.ui).to receive(:output).with(users)
+      @knife.run
+    end
+  end
+
+  describe "with all_info argument" do
+    before do
+      allow(@rest).to receive(:get).with("users?verbose=true").and_return(users)
+      @knife.config[:all_info] = true
+    end
+
+    it "list all user with more detail about a user" do
+      expect(@knife.ui).to receive(:output)
+      .with([ 
+        { :display_name => "Test User1", 
+          :email => "test_user1@example.com", 
+          :first_name=> "Test", 
+          :last_name => "User1", 
+          :username => "test_user1"
+        },
+        { :display_name=> "Test User2", 
+          :email=> "agupta@example.com", 
+          :first_name=> "Test", 
+          :last_name=> "User2", 
+          :username => "test_user2"
+        }
+      ])
+      @knife.run
+    end
+  end
+end

--- a/spec/unit/user_list_spec.rb
+++ b/spec/unit/user_list_spec.rb
@@ -9,14 +9,14 @@ describe Opc::OpcUserList do
         "email": "test_user1@example.com",
         "first_name": "Test",
         "last_name": "User1",
-        "display_name": "Test User1"
+        "display_name": "Test User1",
       },
       "test_user2" => {
         "email": "agupta@example.com",
         "first_name": "Test",
         "last_name": "User2",
-        "display_name": "Test User2"
-      }
+        "display_name": "Test User2",
+      },
 
     }
   end
@@ -39,7 +39,7 @@ describe Opc::OpcUserList do
     let(:users) do
       {
        "test_user1" =>  "https://example.com/organizations/test_org1/users/test_user1",
-       "test_user2" => "https://example.com/organizations/test_org2/users/test_user2"
+       "test_user2" => "https://example.com/organizations/test_org2/users/test_user2",
       }
     end
 
@@ -61,19 +61,19 @@ describe Opc::OpcUserList do
 
     it "list all user with more detail about a user" do
       expect(@knife.ui).to receive(:output)
-      .with([ 
-        { :display_name => "Test User1", 
-          :email => "test_user1@example.com", 
-          :first_name=> "Test", 
-          :last_name => "User1", 
-          :username => "test_user1"
+        .with([
+        { display_name: "Test User1",
+          email: "test_user1@example.com",
+          first_name: "Test",
+          last_name: "User1",
+          username: "test_user1",
         },
-        { :display_name=> "Test User2", 
-          :email=> "agupta@example.com", 
-          :first_name=> "Test", 
-          :last_name=> "User2", 
-          :username => "test_user2"
-        }
+        { display_name: "Test User2",
+          email: "agupta@example.com",
+          first_name: "Test",
+          last_name: "User2",
+          username: "test_user2",
+        },
       ])
       @knife.run
     end

--- a/spec/unit/user_list_spec.rb
+++ b/spec/unit/user_list_spec.rb
@@ -60,21 +60,7 @@ describe Opc::OpcUserList do
     end
 
     it "list all user with more detail about a user" do
-      expect(@knife.ui).to receive(:output)
-        .with([
-        { display_name: "Test User1",
-          email: "test_user1@example.com",
-          first_name: "Test",
-          last_name: "User1",
-          username: "test_user1",
-        },
-        { display_name: "Test User2",
-          email: "agupta@example.com",
-          first_name: "Test",
-          last_name: "User2",
-          username: "test_user2",
-        },
-      ])
+      expect(@knife.ui).to receive(:output).with(users)
       @knife.run
     end
   end


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

### Description

- Added `all_info` option in user list command.
- Added rspec for opc user list feature.

### Command
- `knife opc user list --all-info`

### Output:
```
antima_gupta:
  display_name: Antima Gupta
  email:        agupta@example.com
  first_name:   Antima
  last_name:    Gupta
pivotal:
  display_name: Chef Server Superuser
  email:        root@localhost.localdomain
  first_name:   Chef
  last_name:    Server

```

### Issues Resolved
 # https://github.com/chef/chef-server/issues/2080

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG