### PR TITLE
Fix the password prompting in the user create command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
     gem "chef-zero", "~> 14"
     gem "chef", "~> 15"
   else
-    gem "chef"
+    gem "chef", "~> 16"
   end
   gem "chefstyle"
   gem "rspec", "~> 3.0"

--- a/lib/chef/knife/opc_user_create.rb
+++ b/lib/chef/knife/opc_user_create.rb
@@ -95,7 +95,7 @@ module Opc
     end
 
     def prompt_for_password
-      ui.ask("Please enter the user's password: ") { |q| q.echo = false }
+      ui.ask("Please enter the user's password: ", echo: false)
     end
   end
 end


### PR DESCRIPTION
This throws an error on a missing method. Do it the same way we do in the user create plugin in knife itself.

Signed-off-by: Tim Smith <tsmith@chef.io>